### PR TITLE
feat: add custom queryFilter

### DIFF
--- a/src/rln_contract.ts
+++ b/src/rln_contract.ts
@@ -161,5 +161,3 @@ function splitToChunks(
 
   return chunks;
 }
-
-// tmp.contract.queryFilter(tmp.membersFilter, 7109391, 8888520).then(console.log)

--- a/src/rln_contract.ts
+++ b/src/rln_contract.ts
@@ -197,7 +197,8 @@ function* takeN<T>(array: T[], size: number): Iterable<T[]> {
 }
 
 function ignoreErrors<T>(promise: Promise<T>, defaultValue: T): Promise<T> {
-  return promise.catch((_) => {
+  return promise.catch((err) => {
+    console.error(`Ignoring an error during query: ${err?.message}`);
     return defaultValue;
   });
 }


### PR DESCRIPTION
Addressing the issue when `RLNContract` cannot fetch history if the range is too wide. 
More details on the issue: https://github.com/waku-org/js-waku-examples/pull/225#discussion_r1171770082