### PR TITLE
fix: failing README instructions for example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ Or to use ESM import directly from a `<script>` tag:
 ```
 git clone https://github.com/waku-org/js-rln
 
-cd js-rln/example
+cd js-rln/
+
+npm install
+
+cd example/
 
 npm install  # or yarn
 


### PR DESCRIPTION
When you run `npm install` in `example/` dir without previously running `npm install` in root dir it will fail with 

```
npm ERR! command failed
npm ERR! command sh -c husky install
npm ERR! sh: 1: husky: not found
```