### PR TITLE
fix: use correct offset when converting commitment to bigint

### DIFF
--- a/src/identity.ts
+++ b/src/identity.ts
@@ -14,7 +14,7 @@ export class IdentityCredential {
     const idNullifier = memKeys.subarray(32, 64);
     const idSecretHash = memKeys.subarray(64, 96);
     const idCommitment = memKeys.subarray(96);
-    const idCommitmentBigInt = buildBigIntFromUint8Array(idCommitment);
+    const idCommitmentBigInt = buildBigIntFromUint8Array(idCommitment, 96);
 
     return new IdentityCredential(
       idTrapdoor,

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -61,9 +61,12 @@ export function writeUIntLE(
  * @param array: Uint8Array
  * @returns BigInt
  */
-export function buildBigIntFromUint8Array(array: Uint8Array): bigint {
+export function buildBigIntFromUint8Array(
+  array: Uint8Array,
+  byteOffset: number = 0
+): bigint {
   const dataView = new DataView(array.buffer);
-  return dataView.getBigUint64(0, true);
+  return dataView.getBigUint64(byteOffset, true);
 }
 
 /**


### PR DESCRIPTION
The function that converts a `Uint8Array` to `bigint` was using a `DataView` to access the underlying buffer representing the credentials generated from zerokit. By accessing the buffer of a `subarray` directly without specifying the offset, it reads bytes from the beginning of the buffer, which results in the `bigint` representation of `IdTrapdoor` NOT `IdCommitment`. Applications using the library to generate credentials would end up sending the wrong value to the RLN smart contract.

Fix is to add the correct offset to the `DataView`.